### PR TITLE
Don't JSON.parse req.body when using bodyParser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,8 @@ app.post('/events', (req, res) => {
       break;
     }
     case 'event_callback': {
-      const body = JSON.parse(req.body.payload);
-      if (body.token === process.env.SLACK_VERIFICATION_TOKEN) {
-        const event = req.body.event;
-
+      const { token, event } = req.body;
+      if (token === process.env.SLACK_VERIFICATION_TOKEN) {
         // `team_join` is fired whenever a new user (incl. a bot) joins the team
         // check if `event.is_restricted == true` to limit to guest accounts
         if (event.type === 'team_join' && !event.is_bot) {
@@ -55,10 +53,10 @@ app.post('/events', (req, res) => {
  * verification token before continuing.
  */
 app.post('/interactive-message', (req, res) => {
-  if (req.body.token === process.env.SLACK_VERIFICATION_TOKEN) {
+  const { token, user, team } = JSON.parse(req.body.payload);
+  if (token === process.env.SLACK_VERIFICATION_TOKEN) {
     // simplest case with only a single button in the application
     // check `callback_id` and `value` if handling multiple buttons
-    const { user, team } = JSON.parse(req.body.payload);
     onboard.accept(user.id, team.id);
     res.send({ text: 'Thank you! The Terms of Service have been accepted.' });
   } else { res.sendStatus(500); }


### PR DESCRIPTION
This PR fixes a few errors in regards trying to parse the body from JSON when it's already been converted by the bodyParser. Also, it'll parse the `payload` key in the body which is just a string.